### PR TITLE
doc/Makefile.in doesn't exist anymore

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])
 
 AM_INIT_AUTOMAKE([-Wall])
-AC_CONFIG_FILES([Makefile doc/Makefile])
+AC_CONFIG_FILES([Makefile])
 AC_CONFIG_MACRO_DIR([m4])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
The Makefile in doc/ was changed to not being generated from a Makefile.am anymore, but configure.ac still expected this to be the case.