### PR TITLE
expect that server is now built with --with-systemd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,7 @@ DISTCHECK_CONFIGURE_FLAGS = \
 SUBDIRS = . tests
 
 bin_SCRIPTS = $(setup)
-libexec_SCRIPTS = $(ctl) $(checkdb)
+libexec_SCRIPTS = $(checkdb)
 
 legacyscriptsdir = $(systemdlegacyscriptsdir)/$(NAME_SERVICE)
 
@@ -52,7 +52,8 @@ noinst_DATA =
 # TODO: Ideally, 'make distcheck' should check every file we generate.
 if WANT_SYSVINIT
 noinst_DATA += $(initscript)
-GENERATED_FILES += $(initscript)
+libexec_SCRIPTS += $(ctl)
+GENERATED_FILES += $(initscript) $(ctl)
 else
 systemdunits_DATA = $(service) $(serviceat)
 legacyscripts_SCRIPTS = initdb upgrade

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+New in 8.0 version:
+
+* PostgreSQL on systems with systemd are now configured with
+  --with-systemd, which simplifies the start/stop handling (we can
+  stop shipping postgresql-ctl wrapper, e.g.).
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 New in 7.0 version:
 
 * RPM macros file works with SCLs, too.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Use the MAJ.MIN[~SUFF].  Note that X.X > X.X~SUFF!
-AC_INIT([postgresql-setup], [7.0], [praiskup@redhat.com])
+AC_INIT([postgresql-setup], [8.0~dev], [praiskup@redhat.com])
 AC_CONFIG_AUX_DIR(auxdir)
 config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])

--- a/postgresql.service.in
+++ b/postgresql.service.in
@@ -9,7 +9,7 @@ Description=PostgreSQL database server
 After=network.target
 
 [Service]
-Type=forking
+Type=notify
 
 User=postgres
 Group=postgres
@@ -26,20 +26,16 @@ OOMScoreAdjust=-1000
 Environment=PG_OOM_ADJUST_FILE=/proc/self/oom_score_adj
 Environment=PG_OOM_ADJUST_VALUE=0
 
-# Maximum number of seconds pg_ctl will wait for postgres to start.  Note that
-# PGSTARTTIMEOUT should be less than TimeoutSec value.
-Environment=PGSTARTTIMEOUT=270
-
 @PGDATA_ENVIRONMENT@
 
 ExecStartPre=@libexecdir@/postgresql-check-db-dir %N
-
-# Use convenient postgresql-ctl wrapper instead of directly pg_ctl.  See the
-# postgresql-ctl file itself for more info.
-
-ExecStart=@libexecdir@/postgresql-ctl start -D ${PGDATA} -s -w -t ${PGSTARTTIMEOUT}
-ExecStop=@libexecdir@/postgresql-ctl stop -D ${PGDATA} -s -m fast
-ExecReload=@libexecdir@/postgresql-ctl reload -D ${PGDATA} -s
+# Even though the $PGDATA variable is exported (postmaster would accept that)
+# use the -D option here so PGDATA content is printed by /bin/ps and by
+# 'systemctl status'.
+ExecStart=@bindir@/postmaster -D ${PGDATA}
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=mixed
+KillSignal=SIGINT
 
 # Give a reasonable amount of time for the server to start up/shut down.
 # Ideally, the timeout for starting PostgreSQL server should be handled more


### PR DESCRIPTION
systemd: sd_notify support
* Makefile.am: Don't generate/install postgresql-ctl for systemd
systems.
* postgresql.service.in: Use Type=notify, fix Exec* statements (we
don't have to use the postgresql-ctl wrapper. KillMode=mixed is
needed for the master/slave process design of PostgreSQL server.
Drop the PGSTARTTIMEOUT variable, which is not used now (only the
TimeoutSec is used now, but see rhbz#1525477).
