### PR TITLE
service: disable start/stop killing timeout policy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,9 @@ New in 8.0 version:
   --with-systemd, which simplifies the start/stop handling (we can
   stop shipping postgresql-ctl wrapper, e.g.).
 
+* systemd service doesn't have the artificial timeout for PostgreSQL
+  server start/stop (was 10 minutes before).
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 7.0 version:

--- a/postgresql.service.in
+++ b/postgresql.service.in
@@ -37,10 +37,8 @@ ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT
 
-# Give a reasonable amount of time for the server to start up/shut down.
-# Ideally, the timeout for starting PostgreSQL server should be handled more
-# nicely by pg_ctl in ExecStart, so keep its timeout smaller than this value.
-TimeoutSec=300
+# No artificial start/stop timeout (rhbz#1525477, pgrpms#2786).
+TimeoutSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* postgresql.service.in (TimeoutSec): Set to 0 (infinity).