### PR TITLE
add postgresql-upgrade script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ postgresql*-check-db-dir
 postgresql*-ctl
 postgresql*-new-systemd-unit
 postgresql*.service
-/postgresql*-setup
+postgresql*-setup
+postgresql*-upgrade
 postgresql*-setup.1
 README.rpm-dist*
 testsuite

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,12 @@
 
 New in 8.5 version:
 
-*
+* Added 'postgresql-upgrade <DATADIR>' command.  This is similar to
+  'postgresql-setup --upgrade', but is useful to upgrade DATADIR for
+  PostgreSQL servers which were run a non-standard way (under non-standard
+  user, or without systemd service).  Typical use-case can be to migrate
+  database for KDE's Akonadi server;  it is running it's own PostgreSQL server
+  with datadir in user's ~/.local/ directory (under user's UID process).
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/bin/Makefile.inc
+++ b/bin/Makefile.inc
@@ -1,9 +1,15 @@
 setup		= %D%/$(NAME_BINARYBASE)-setup
 setup_in	= %D%/postgresql-setup.in
 
-bin_SCRIPTS = $(setup)
+postgresql_upgrade = %D%/$(NAME_BINARYBASE)-upgrade
+postgresql_upgrade_in = %D%/$(NAME_BINARYBASE)-upgrade.in
+
+bin_SCRIPTS = $(setup) $(postgresql_upgrade)
 
 $(setup): $(setup_in) $(text_tpl_deps)
 	$(text_tpl_gen_script)
 
-EXTRA_DIST += $(setup_in)
+$(postgresql_upgrade): $(postgresql_upgrade_in) $(text_tpl_deps)
+	$(text_tpl_gen_script)
+
+EXTRA_DIST += $(setup_in) $(postgresql_upgrade_in)

--- a/bin/postgresql-upgrade.in
+++ b/bin/postgresql-upgrade.in
@@ -1,0 +1,213 @@
+#! /bin/bash
+
+# postgresql-upgrade - one-hit shell command running initdb && pg_upgrade with
+# preconfigured options to simplify the upgrade process.  This script has
+# nothing to do with systemd services, for upgrading systemd postgresql services
+# please use @bindir@/postgresql-setup.
+
+set -e
+
+builddir_source ()
+{
+    # To simplify manpage generator.  Build-time-only.
+    file=$(echo "$1" | sed -e "s|@rawpkgdatadir@|share/postgresql-setup|")
+    . "@abs_top_builddir@/$file"
+}
+
+builddir_source "@rawpkgdatadir@/library.sh"
+
+run_cmd ()
+{
+    echo >&2
+    info "cmd: $(eval echo "$1")"
+    echo >&2
+    eval "$1"
+}
+
+run_cmd_args ()
+{
+    local space='' cmd=''
+    for arg; do
+        cmd+="$space$(printf %q "$arg")"
+        space=' '
+    done
+    run_cmd "$cmd"
+}
+
+# We upgrade by default from system's default PostgreSQL installation
+option_upgradefrom="@NAME_DEFAULT_PREV_SERVICE@"
+
+# PostgreSQL data directory after upgrade.
+option_datadir=
+
+# For non-inplace upgrades.
+option_datadir_old=
+
+# use pg_upgrade --link?
+option_hardlink=false
+
+# ensure privacy
+umask 0077
+
+: "${RESTORECON=/sbin/restorecon}"
+test -x "$RESTORECON" || RESTORECON=:
+
+@SCL_SOURCE@
+
+PGENGINE=@bindir@
+
+long_opts="\
+upgrade-ids,\
+upgrade-from:,\
+version,usage,help"
+
+USAGE_STRING="Usage: $0 [--upgrade-from=ID] DATADIR
+
+Wrapper script for pg_upgrade.  It has pre-configured pg_upgrade options and
+environment variables.
+
+Options:
+  --upgrade-ids              Print list of available IDs of upgrade scenarios to
+                             standard output.
+  --upgrade-from=ID          Specify id \"old\" postgresql stack to upgrade
+                             from.  List of available IDs can be listed by
+                             --upgrade-ids.  Default is '$option_upgradefrom'.
+
+Other options:
+  --help                     show this help
+  --version                  show version of this package
+
+Environment:
+  PGSETUP_INITDB_OPTIONS     Options carried by this variable are passed to
+                             subsequent call of \`initdb\` binary (see man
+                             initdb(1)).  This variable is used also during
+                             'upgrade' mode because the new cluster is actually
+                             re-initialized from the old one.
+  PGSETUP_PGUPGRADE_OPTIONS  Options in this variable are passed next to the
+                             subsequent call of \`pg_upgrade\`.  For more info
+                             about possible options please look at man
+                             pg_upgrade(1)."
+
+print_version()
+{
+    echo "@NAME_BINARYBASE@-upgrade @VERSION@"
+    echo "Built against PostgreSQL version @PGVERSION@."
+}
+
+args=$(getopt -o "" -l "$long_opts" -n "@NAME_BINARYBASE@-setup" -- "$@")
+eval set -- "$args"
+
+while true; do
+    case "$1" in
+    --help|--usage)
+        echo "$USAGE_STRING"
+        exit 0
+        ;;
+
+    --upgrade-from)
+        option_upgradefrom="$2"
+        shift 2
+        ;;
+
+    --upgrade-ids)
+        parse_upgrade_setup help
+        exit 0
+        ;;
+
+    --version)
+        print_version
+        exit 0
+        ;;
+
+    --)
+        shift
+        break
+        ;;
+
+    *)
+        die "author's fault: option $1 not handled"
+        break
+        ;;
+    esac
+done
+
+test $# -eq 1 || die "exactly one DATADIR option required"
+option_datadir=$(readlink -f "$1") || die "wrong datadir $1"
+
+inplace=false
+test -n "$option_datadir_old" || {
+    option_datadir_old=${option_datadir}_old
+    option_hardlink=:
+    inplace=:
+}
+
+if ! parse_upgrade_setup config "$option_upgradefrom"; then
+    die "bad --upgrade-from parameter '$option_upgradefrom'," \
+        "try --upgrade-ids"
+fi
+
+version_file=$option_datadir/PG_VERSION
+
+test -f "$version_file" || die "can't read '$version_file'"
+
+old_data_version="$(cat "$version_file")"
+
+if test "$old_data_version" != "$upgradefrom_major"; then
+    error   "Cannot upgrade because the database in $option_datadir of"
+    error_q "version $old_data_version but it should be $upgradefrom_major"
+    exit 1
+fi
+
+if [ ! -x "$upgradefrom_engine/postgres" ]; then
+    error "Please install the $upgradefrom_package package."
+    exit 1
+fi
+
+exit_handler_revert_datadir=false
+
+exit_handler ()
+{
+    exit_status=$?
+
+    ! $exit_handler_revert_datadir || {
+        info "restoring previous datadir"
+        rm -rf "$option_datadir"
+        mv "$option_datadir_old" "$option_datadir"
+    }
+
+    exit $exit_status
+}
+
+trap exit_handler EXIT
+
+if $inplace; then
+    ! test -e "$option_datadir_old" || die "$option_datadir_old already exists"
+    mv "$option_datadir" "$option_datadir_old"
+    exit_handler_revert_datadir=:
+fi
+
+test -e "$option_datadir" || mkdir "$option_datadir"
+$RESTORECON "$option_datadir"
+
+initdbcmd="\"\$PGENGINE\"/initdb --pgdata=\"\$option_datadir\" --auth=ident $PGSETUP_INITDB_OPTIONS"
+run_cmd "$initdbcmd"
+
+test -n "$option_workdir" || {
+    option_workdir=$(mktemp -d "/tmp/postgresql_upgrade_XXXXXX")
+    info "logs are stored in $option_workdir"
+}
+cd "$option_workdir"
+
+set -- "$PGENGINE"/pg_upgrade \
+        --old-bindir="$upgradefrom_engine" \
+        --new-bindir="$PGENGINE" \
+        --old-datadir="$option_datadir_old" \
+        --new-datadir="$option_datadir"
+
+$option_hardlink && set -- "$@" --link
+
+test -n "$PGSETUP_PGUPGRADE_OPTIONS" && eval 'set -- "$@" '"$PGSETUP_PGUPGRADE_OPTIONS"
+
+run_cmd_args "$@"
+exit_handler_revert_datadir=false
+info "old data directory and configuration is in $option_datadir_old"

--- a/doc/Makefile.inc
+++ b/doc/Makefile.inc
@@ -23,9 +23,11 @@ HELP2MAN_RUN = \
 
 setup_man = %D%/$(NAME_BINARYBASE)-setup.1
 
+upgrade_man = %D%/$(NAME_BINARYBASE)-upgrade.1
+
 new_unit_man = %D%/$(NAME_BINARYBASE)-new-systemd-unit.1
 
-dist_man_MANS = $(setup_man)
+dist_man_MANS = $(setup_man) $(upgrade_man)
 
 if ! WANT_SYSVINIT
 dist_man_MANS += $(new_unit_man)
@@ -36,10 +38,15 @@ $(setup_man): $(builddir)/bin/$(NAME_BINARYBASE)-setup $(lib)
 	export input=$(builddir)/bin/$(NAME_BINARYBASE)-setup ; \
 	    $(HELP2MAN_RUN)
 
+$(upgrade_man): $(builddir)/bin/$(NAME_BINARYBASE)-upgrade $(lib)
+	$(AM_V_GEN)odir=`dirname "$@"` ; mkdir -p "$$odir" ; \
+	export input=$(builddir)/bin/$(NAME_BINARYBASE)-upgrade ; \
+	    $(HELP2MAN_RUN)
+
 $(new_unit_man): sbin/$(NAME_BINARYBASE)-new-systemd-unit $(lib)
 	$(AM_V_GEN)odir=`dirname "$@"`; mkdir -p "$$odir" ; \
 	export PGSETUP_TEST=: ; \
 	export input=$(builddir)/sbin/$(NAME_BINARYBASE)-new-systemd-unit ; \
 	    $(HELP2MAN_RUN)
 
-DISTCLEANFILES += $(setup_man) $(new_unit_man)
+DISTCLEANFILES += $(dist_man_MANS) $(new_unit_man)


### PR DESCRIPTION
```
* Added 'postgresql-upgrade <DATADIR>' command.  This is similar to
  'postgresql-setup --upgrade', but is useful to upgrade DATADIR for
  PostgreSQL servers which were run a non-standard way (under non-standard
  user, or without systemd service).  Typical use-case can be to migrate
  database for KDE's Akonadi server;  it is running it's own PostgreSQL server
  with datadir in user's ~/.local/ directory (under user's UID process).
```


Can be tested by:
```bash
./configure --prefix=/usr
make && sudo make install
postgresql-upgrade /some/data/directory
```