### PR TITLE
macros: the '&& cmd' ignores 'set -e'

### DIFF
--- a/share/postgresql-setup/postgresql_pkg_tests.sh.in
+++ b/share/postgresql-setup/postgresql_pkg_tests.sh.in
@@ -91,8 +91,10 @@ pgtests_start ()
         fi
     fi
 
-    __pgtests_initdb && __TRAP_ACTIONS="pgtests_cleanup $__TRAP_ACTIONS"
-    __pgtests_start  && __TRAP_ACTIONS="pgtests_stop $__TRAP_ACTIONS"
+    __pgtests_initdb
+    __TRAP_ACTIONS="pgtests_cleanup $__TRAP_ACTIONS"
+    __pgtests_start
+    __TRAP_ACTIONS="pgtests_stop $__TRAP_ACTIONS"
     __pgtests_create_admins_db
 
     __pgtests_passwd "$PGTESTS_ADMIN" "$PGTESTS_ADMINPASS"


### PR DESCRIPTION
* share/postgresql-setup/postgresql_pkg_tests.sh.in: Don't use
'cmd && cmd' statements in 'set -e' shell environment - in
rpmbuild.