### PR TITLE
fix datadir log directory for PG v10+

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+New in 8.3 version:
+
+* postgresql-setup creates correct 'log_directory' based on PG version
+  (the default changed from $datadir/pg_log to $datadir/log in v10).
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 New in 8.2 version:
 
 * %postgresql_tests_* macros now use random port for the test PostgreSQL

--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -164,8 +164,8 @@ perform_initdb()
     "${initdbcmd[@]}" >> "$initdb_log" 2>&1 < /dev/null
 
     # Create directory for postmaster log files
-    mkdir "$pgdata/pg_log"
-    $RESTORECON "$pgdata/pg_log"
+    mkdir "$pgdata/@PGLOGDIR_BASENAME@"
+    $RESTORECON "$pgdata/@PGLOGDIR_BASENAME@"
 
     # This if-fork is just to not unnecessarily overwrite what upstream
     # generates by initdb (upstream implicitly uses PGPORT_DEF).

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Use the MAJ.MIN[~SUFF].  Note that X.X > X.X~SUFF!
-AC_INIT([postgresql-setup], [8.2], [praiskup@redhat.com])
+AC_INIT([postgresql-setup], [8.3], [praiskup@redhat.com])
 AC_CONFIG_AUX_DIR(auxdir)
 config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])
@@ -105,6 +105,11 @@ AX_COMPARE_VERSION([9.4], [le], [$PGVERSION],
   [PG_UPGRADE_BIN_USER_OPT="--username"],
   [PG_UPGRADE_BIN_USER_OPT="--user"])
 _AX_TEXT_TPL_SUBST([PG_UPGRADE_BIN_USER_OPT])
+
+PGLOGDIR_BASENAME=log
+AX_COMPARE_VERSION([10], [gt], [$PGVERSION],
+  [PGLOGDIR_BASENAME=pg_log])
+_AX_TEXT_TPL_SUBST([PGLOGDIR_BASENAME])
 
 AC_PATH_PROG([PG_UPGRADE_BIN], [pg_upgrade])
 


### PR DESCRIPTION
* bin/postgresql-setup.in: Create '$pgdata/log' for PG 10+, and
'$pgdata/pg_log' for PG < 10.
* configure.ac: Define PGLOGDIR_BASENAME based on PGVERSION.