### PR TITLE
service: fix ExecStart= for Red Hat Software Collections

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ New in 8.3 version:
   postgresql-server(:MODULE_COMPAT_11) to avoid clash with non-modular
   builds.
 
+* Fixed ExecStart= statement in systemd's service files for Software
+  Collections where we need to first do `source scl_source COLLECTION ;`
+  before we execute postmaster.
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 New in 8.2 version:

--- a/configure.ac
+++ b/configure.ac
@@ -148,6 +148,9 @@ AC_ARG_WITH([scl],
             [AS_HELP_STRING([--with-scl],
                             [Build against Software Collections RPM])],
             [scl_enabled_build=:])
+
+SYSTEMD_EXECSTART='${bindir}/postmaster -D $${PGDATA}'
+
 if $scl_enabled_build; then
     AC_MSG_CHECKING([which SCL to build against])
     SCL=`rpm --eval %scl`
@@ -157,6 +160,8 @@ if $scl_enabled_build; then
         SCL_SHELL_WRAPPER="$SCL_BINDIR/$SCL_BINARY enable $SCL -- "
         SCL_SOURCE="source scl_source enable $SCL"
         AC_MSG_RESULT([$SCL])
+
+        SYSTEMD_EXECSTART="/bin/sh -c '\''source scl_source enable ${SCL} ; exec postmaster -D \$\${PGDATA}'\''"
 
         # The variables below override the detected default here.
         test x = x"$NAME_SRV_PFX" && NAME_SRV_PFX=$SCL-
@@ -193,6 +198,7 @@ PGSETUP_SUBST_OPT([rpmmacrosdir], [],
 
 _AX_TEXT_TPL_SUBST([SCL_SHELL_WRAPPER])
 _AX_TEXT_TPL_SUBST([SCL_SOURCE])
+_AX_TEXT_TPL_SUBST([SYSTEMD_EXECSTART])
 
 NAME_BINARYBASE="$NAME_BIN_PFX""postgresql$NAME_BIN_SFX"
 NAME_PACKAGE="$NAME_PKG_PFX""postgresql$NAME_PKG_SFX"

--- a/postgresql.service.in
+++ b/postgresql.service.in
@@ -32,7 +32,7 @@ ExecStartPre=@libexecdir@/postgresql-check-db-dir %N
 # Even though the $PGDATA variable is exported (postmaster would accept that)
 # use the -D option here so PGDATA content is printed by /bin/ps and by
 # 'systemctl status'.
-ExecStart=@bindir@/postmaster -D ${PGDATA}
+ExecStart=@SYSTEMD_EXECSTART@
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=mixed
 KillSignal=SIGINT


### PR DESCRIPTION
```

    Historically we used `pg_ctl` in ExecStart=, which we later
    wrapped into postgresql-ctl script - and later we moved to
    /bin/postmaster directly.

    The postgresql-ctl script had two purposes:
    (a) some additional/compat logic on top of pg_ctl and
    (b) it enabled the software collection by `scl_source`.
    When we moved to ExecStart=/bin/postmaster we realized that (a) is
    not needed anymore but we forgot about (b).

    Now we got report that server fails to load modules because it
    doesn't have LD_LIBRARY_PATH set accordingly in Software
    Collections scenario.
    
    Ideally, we would wrap %_bindir/postmaster by something like
    %_bindir/postmaster-scl.  But this would mean that we'd have to
    request selinux-policy change, and wait till it gets updated.  So
    instead of shell wrapper script, invoke /bin/sh directly.  The
    /bin/sh is symlink to /bin/bash, which has shell_exec_t label;
    and SELinux policy allows shell_exec_t -> postgresql_exec_t ->
    postgresql_t transition.
    
    This started to be an issue after sd_notify switch, done in
    925b34c73a887da5c3d0cfd5cfa578b8c3665211.
    
    Related: rhbz#1550567, rhbz#1631185
```
