### PR TITLE
Better detect RedHat-like OSs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,17 +113,29 @@ _AX_TEXT_TPL_SUBST([PGLOGDIR_BASENAME])
 
 AC_PATH_PROG([PG_UPGRADE_BIN], [pg_upgrade])
 
-if test -z "$PKGCONFIG_DIR" -a "$pgsetup_cv_os_family" = redhat; then
-    PKGCONFIG_DIR=/etc/postgresql
+if test -z "$PKGCONFIG_DIR"; then
+   case $pgsetup_cv_os_family in
+   redhat|fedora|amazon)
+     PKGCONFIG_DIR=/etc/postgresql
+     ;;
+   esac
 fi
 
-if test -z "$POSTGRES_HOMEDIR" -a "$pgsetup_cv_os_family" = redhat; then
-    POSTGRES_HOMEDIR=/var/lib/pgsql
+if test -z "$POSTGRES_HOMEDIR"; then
+   case $pgsetup_cv_os_family in
+   redhat|fedora|amazon)
+     POSTGRES_HOMEDIR=/var/lib/pgsql
+     ;;
+   esac
 fi
 
-if test -z "$PGDATADIR" -a "$pgsetup_cv_os_family" = redhat; then
-    # This is based on Red Hat's packaging.
-    PGDATADIR='${localstatedir}/lib/pgsql/data'
+if test -z "$PGDATADIR"; then
+   case $pgsetup_cv_os_family in
+   redhat|fedora|amazon)
+     # This is based on Red Hat's packaging.
+     PGDATADIR='${localstatedir}/lib/pgsql/data'
+     ;;
+   esac
 fi
 
 README_DIST_BASENAME=README.rpm-dist

--- a/m4/packaging.m4
+++ b/m4/packaging.m4
@@ -1,16 +1,20 @@
 AC_DEFUN([PGSETUP_PACKAGING_INIT], [
   AC_CACHE_CHECK(
-    [for operating system (distribution)],
+    [for operating system (distribution) family],
     [pgsetup_cv_os_family], [
       pgsetup_cv_os_family=
       if test -r /etc/redhat-release; then
-        pgsetup_cv_os_family=redhat
+        pgsetup_cv_os_family=redhat;
+      elif grep -c 'ID="amzn"' /etc/os-release > /dev/null; then
+        pgsetup_cv_os_family=amazon;
+      elif grep -c 'ID_LIKE=.*fedora' /etc/os-release > /dev/null; then
+        pgsetup_cv_os_family=fedora;
       fi
     ]
   )
 
   case $pgsetup_cv_os_family in
-  redhat)
+  redhat|fedora|amazon)
     AC_PATH_PROG([RPM], [rpm])
     if test -z "$ac_cv_path_RPM"; then
       AC_MSG_ERROR("can not find RPM package manager")

--- a/m4/packaging.m4
+++ b/m4/packaging.m4
@@ -1,6 +1,6 @@
 AC_DEFUN([PGSETUP_PACKAGING_INIT], [
   AC_CACHE_CHECK(
-    [for oprating system (distribution)],
+    [for operating system (distribution)],
     [pgsetup_cv_os_family], [
       pgsetup_cv_os_family=
       if test -r /etc/redhat-release; then


### PR DESCRIPTION
Not all redhat-like OSs have a `/etc/redhat-release` file, so look for ID and ID_LIKE in `/etc/os-release` as a fallback.