### PR TITLE
Block execution with custom pgdata entry (as release 8.6)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,12 @@
 
 New in 8.6 version:
 
-*
+* Block execution when 'data_directory' in configuration file is detected.
+  Currently postgresql-{setup, upgrade} doesn't support custom data directory.
+  All changes connected with 'data_directory' made in .conf or .service file
+  should be reverted before usage.
+  That means that detected PGDATA variable in .service file and 'data_directory'
+  in .conf file should be restored to default values.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.release
+++ b/README.release
@@ -3,10 +3,16 @@
 1. Get the maintainer's tools:
 
 ```
-yum install autoconf automake autoconf-archive make
+dnf install autoconf automake autoconf-archive make
 ```
 
-2. Get `gitlog-to-changelog` tool:
+2. Install postgresql-server:
+
+```
+dnf install postgresql-server
+```
+
+3. Get `gitlog-to-changelog` tool:
 
 ```
 wget https://raw.githubusercontent.com/manuelbua/gitver/master/gitlog-to-changelog
@@ -14,23 +20,23 @@ chmod a+x gitlog-to-changelog
 PATH="$(pwd):$PATH"
 ```
 
-3. Git release administrative -- a commit like this: https://github.com/devexp-db/postgresql-setup/commit/3cf4aaa5
+4. Git release administrative -- a commit like this: https://github.com/devexp-db/postgresql-setup/commit/3cf4aaa5
 
-4. Add a tag for the release
+5. Add a tag for the release
 
 ```
 git tag -a v8.6 -m "Release v8.6"
 ```
 
-5. Post-release administrative -- a commit like this: https://github.com/devexp-db/postgresql-setup/commit/c7ed7144
+6. Post-release administrative -- a commit like this: https://github.com/devexp-db/postgresql-setup/commit/c7ed7144
 
-6. Push the changes
+7. Push the changes
 
 ```
 git push
 ```
 
-7. Create a tarball
+8. Create a tarball
 ```
 # aclocal
 # automake --add-missing
@@ -40,7 +46,7 @@ autoreconf -vfi
 make dist-gzip
 ```
 
-8. Upload the tarball to github and create a release from the new tag like this: https://github.com/devexp-db/postgresql-setup/releases/tag/v8.5
+9. Upload the tarball to github and create a release from the new tag like this: https://github.com/devexp-db/postgresql-setup/releases/tag/v8.5
 
 https://github.com/devexp-db/postgresql-setup/releases/new
 

--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -460,12 +460,13 @@ handle_pgconf()
     }
 
     local sp='[[:space:]]'
-    local sed_expr="s/^$sp*port$sp*=$sp\([0-9]\+\).*/\1/p"
+    local sed_expr_port="s/^$sp*port$sp*=$sp*\([0-9]\+\).*/\1/p"
+    local sed_expr_pgdata="s/^$sp*data_directory$sp*=\(.*\)/\1/p"
 
-    rv=0
-    conf_pgport=`sed -n "$sed_expr" $conffile | tail -1` || rv=1
+    conf_pgport=`sed -n "$sed_expr_port" $conffile | tail -1`
+    conf_pgdata=`sed -n "$sed_expr_pgdata" $conffile | tail -1`
     test -n "$conf_pgport" && debug "postgresql.conf pgport: $conf_pgport"
-    return $rv
+    test -n "$conf_pgdata" && debug "postgresql.conf pgdata (data_directory): $conf_pgdata"
 }
 
 
@@ -735,6 +736,19 @@ if test upgrade = "$option_mode"; then
                           "$option_upgradefrom_unit"
     test -n "$option_port" -a "$option_port" != "$pgport" \
         && warn "Old pgport $pgport has bigger priority than --pgport value."
+fi
+
+# Check for data_directory entry in config file
+# valid entry means that custom PGDATA path is present which is not supported
+# BZ (#1935301)
+if test -n "$conf_pgdata"; then
+    error   $"data_directory field in configuration file is not supported."
+    error_q $"db datadir (PGDATA) needs to be specified exclusively in service/unit"
+    error_q $"file as an Environment variable."
+    error_q $"In order to use this script, please remove data_directory entry from"
+    error_q $"configuration file and make sure that the default location"
+    error_q $"(PGDATA) in .service file is valid."
+    exit 1
 fi
 
 # We expect that for upgrade - the previous stack was in working state (thus

--- a/bin/postgresql-upgrade.in
+++ b/bin/postgresql-upgrade.in
@@ -163,6 +163,30 @@ if [ ! -x "$upgradefrom_engine/postgres" ]; then
     exit 1
 fi
 
+# Check for data_directory entry in config file
+# valid entry means that custom PGDATA path is present which is not supported
+# BZ (#1935301)
+conffile="$option_datadir/postgresql.conf"
+
+test -r "$conffile" || {
+    error "config file $conffile is not readable or does not exist"
+    die "Old cluster in '$data' does not seem to be initialized"
+}
+
+sp='[[:space:]]'
+sed_expr_pgdata="s/^$sp*data_directory$sp*=\(.*\)/\1/p"
+conf_pgdata=`sed -n "$sed_expr_pgdata" $conffile | tail -1`
+
+test -n "$conf_pgdata" && {
+    error   $"data_directory field in configuration file ($conffile) is not supported."
+    error_q $"db datadir (PGDATA) cannot be specified in the configuration file."
+    error_q $"In order to use this script for upgrade, please, move the files"
+    error_q $"to the default location first and remove data_directory entry from"
+    error_q $"configuration file."
+
+    exit 1
+}
+
 exit_handler_revert_datadir=false
 
 exit_handler ()

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Use the MAJ.MIN[~SUFF].  Note that X.X > X.X~SUFF!
-AC_INIT([postgresql-setup], [8.6~dev], [praiskup@redhat.com])
+AC_INIT([postgresql-setup], [8.6], [praiskup@redhat.com])
 AC_CONFIG_AUX_DIR(auxdir)
 config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])


### PR DESCRIPTION
When data_directory entry in config file is detected. According to postgresql docs:

> Notice that data_directory overrides -D and PGDATA for the location of the data directory, but not for the location of the configuration files.

That means that detected PGDATA from .service file is incorrect and process should not continue.
Currently postgresql-setup does not take into consideration data_directory entry in configuration file.
Detecting valid data_directory regardless of value should abort execution.