### PR TITLE
Improvement of systemd unit file. Postgresql service should be starte…

### DIFF
--- a/postgresql.service.in
+++ b/postgresql.service.in
@@ -6,7 +6,8 @@
 
 [Unit]
 Description=PostgreSQL database server
-After=network.target
+# We should start postgresql service after network is up (rhbz#2127534 and rhbz#2157651)
+After=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
Improvement of systemd unit file. Postgresql service should be started after the network is up.

The Postgresql server listening on IP address cant be started without properly started network service.
network.target doesn't check whether network is up
Resolves: rhbz#2127534