### PR TITLE
Postgresql upstream do not build postmaster binary

### DIFF
--- a/README.rpm-dist.template
+++ b/README.rpm-dist.template
@@ -74,7 +74,7 @@ m4_divert[]m4_dnl
 
     PGSETUP_ROOT_COMMAND([PGSETUP_SERVICE_START(@NAME_SERVICE@)])
 
-    This command will start a postmaster that will listen on localhost and Unix
+    This command will start a postgres that will listen on localhost and Unix
     socket 5432 only.  Edit @PGDATADIR@/postgresql.conf and pg_hba.conf if you
     want to allow remote access -- see the section on Grand Unified
     Configuration.
@@ -83,7 +83,7 @@ m4_divert[]m4_dnl
 
     PGSETUP_ROOT_COMMAND([PGSETUP_SERVICE_ENABLE(@NAME_SERVICE@)])
 
-    so that the postmaster is automatically started during future reboots.
+    so that the postgres is automatically started during future reboots.
 
   </para>
 
@@ -122,7 +122,7 @@ m4_divert[]m4_dnl
     (for example, from 8.3.x to 9.0.x), you will need to follow the
     "traditional" dump and reload process to bring your data into the new
     version.  That is: *before* upgrading, run pg_dumpall to extract all your
-    data into a SQL file.  Shut down the old postmaster, upgrade to the new
+    data into a SQL file.  Shut down the old postgres, upgrade to the new
     version RPMs, perform initdb, and run the dump file through psql to restore
     your data.
   </para>
@@ -138,7 +138,7 @@ m4_divert[]m4_dnl
     <orderedlist>
       <listitem>
         <para>
-          shut down the old postmaster running against old data
+          shut down the old postgres running against old data
         </para>
       </listitem>
       <listitem>
@@ -332,13 +332,13 @@ m4_ifelse([@WANT_SYSVINIT@], [1], m4_dnl
 [
   <para>
     The @NAME_PACKAGE@-server RPM contains an "initscript" that is used to start
-    the postmaster.  The current version of this script has logic to be able to
-    start multiple postmasters, with different data areas, listening on
+    the postgres.  The current version of this script has logic to be able to
+    start multiple postgress, with different data areas, listening on
     different ports, etc.  To use this functionality requires root access.
   </para>
 
   <para>
-    As an example, let us create a secondary postmaster called, creatively
+    As an example, let us create a secondary postgres called, creatively
     enough, 'secondary'.  Here are the steps:
   </para>
 
@@ -378,7 +378,7 @@ m4_ifelse([@WANT_SYSVINIT@], [1], m4_dnl
     </listitem>
     <listitem>
       <para>
-        Start the postmaster with 'service secondary start'.
+        Start the postgres with 'service secondary start'.
       </para>
     </listitem>
   </orderedlist>
@@ -501,13 +501,13 @@ m4_ifelse([@WANT_SYSVINIT@], [1], m4_dnl
   <para>
     Fedora / Red Hat / CentOS use the systemd package to manage server startup.
     A systemd unit file for PostgreSQL is provided in the server package, as
-    @systemdunitsdir@/@NAME_SERVICE@.service.  To start the postmaster manually,
+    @systemdunitsdir@/@NAME_SERVICE@.service.  To start the postgres manually,
     as root run
     PGSETUP_ROOT_COMMAND(PGSETUP_SERVICE_START(@NAME_SERVICE@))
-    To shut the postmaster down,
+    To shut the postgres down,
     PGSETUP_ROOT_COMMAND(PGSETUP_SERVICE_STOP(@NAME_SERVICE@))
-    These two commands only change the postmaster's current status.  If you want
-    the postmaster to be started automatically during future system startups,
+    These two commands only change the postgres's current status.  If you want
+    the postgres to be started automatically during future system startups,
     run
     PGSETUP_ROOT_COMMAND(PGSETUP_SERVICE_ENABLE(@NAME_SERVICE@))
     To undo that again,
@@ -531,7 +531,7 @@ m4_ifelse([@WANT_SYSVINIT@], [1], m4_dnl
     nonlocal TCP/IP socket connections -- in order to allow these, you will need
     to edit the postgresql.conf file.  The line in question contains the string
     'listen_addresses' -- you need to both uncomment the line and set the value
-    to '*' to get the postmaster to accept nonlocal connections.  You'll also
+    to '*' to get the postgres to accept nonlocal connections.  You'll also
     need to adjust pg_hba.conf appropriately.
   </para>
 </sect1>
@@ -539,7 +539,7 @@ m4_ifelse([@WANT_SYSVINIT@], [1], m4_dnl
 <sect1>
   <title>LOGGING SET UP</title>
   <para>
-    By default, the postmaster's stderr log is directed into files placed in a
+    By default, the postgres's stderr log is directed into files placed in a
     pg_log subdirectory of the data directory (ie, @PGDATADIR@/pg_log).
     The out-of-the-box configuration rotates among seven files, one for each
     day of the week.  You can adjust this by changing postgresql.conf settings.

--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -30,7 +30,7 @@ test x"$PGSETUP_DEBUG" != x && set -x && PS4='${LINENO}: '
 # The current user name.
 USER=$(id -u -n)
 
-# Directory containing the postmaster executable
+# Directory containing the postgres executable
 PGENGINE=@bindir@
 
 # Distribution README file
@@ -171,7 +171,7 @@ perform_initdb()
     eval "initdbcmd+=( $PGSETUP_INITDB_OPTIONS )"
     "${initdbcmd[@]}" >> "$initdb_log" 2>&1 < /dev/null
 
-    # Create directory for postmaster log files
+    # Create directory for postgres log files
     mkdir "$pgdata/@PGLOGDIR_BASENAME@"
     $RESTORECON "$pgdata/@PGLOGDIR_BASENAME@"
 

--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,7 @@ AC_ARG_WITH([scl],
                             [Build against Software Collections RPM])],
             [scl_enabled_build=:])
 
-SYSTEMD_EXECSTART='${bindir}/postmaster -D $${PGDATA}'
+SYSTEMD_EXECSTART='${bindir}/postgres -D $${PGDATA}'
 
 if $scl_enabled_build; then
     AC_MSG_CHECKING([which SCL to build against])

--- a/postgresql.service.in
+++ b/postgresql.service.in
@@ -20,7 +20,7 @@ Group=postgres
 # This is normally controlled by the global default set by systemd
 # StandardOutput=syslog
 
-# Disable OOM kill on the postmaster
+# Disable OOM kill on the postgres
 OOMScoreAdjust=-1000
 # ... but allow it still to be effective for child processes
 # (note that these settings are ignored by Postgres releases before 9.5)
@@ -30,7 +30,7 @@ Environment=PG_OOM_ADJUST_VALUE=0
 @PGDATA_ENVIRONMENT@
 
 ExecStartPre=@libexecdir@/postgresql-check-db-dir %N
-# Even though the $PGDATA variable is exported (postmaster would accept that)
+# Even though the $PGDATA variable is exported (postgres would accept that)
 # use the -D option here so PGDATA content is printed by /bin/ps and by
 # 'systemctl status'.
 ExecStart=@SYSTEMD_EXECSTART@


### PR DESCRIPTION
Postgresql upstream do not build postmaster binary anymore since postgresql 16. So This commit should replace postmaster binary with postgres binary.
Related: https://bugzilla.redhat.com/show_bug.cgi?id=2219370 More info: https://postgrespro.com/blog/pgsql/5969981#commit_81266442