### PR TITLE
handle_service_envfiles: Change EnvironmentFile to EnvironmentFiles

### DIFF
--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -581,7 +581,7 @@ handle_service_envfiles()
     test -z "$envfiles" && return
 
     envfiles=$(echo $envfiles | \
-        sed -e 's/^EnvironmentFile=//' \
+        sed -e 's/^EnvironmentFiles=//' \
             -e 's| ([^)]*)$||'
     )
 


### PR DESCRIPTION
`systemctl show -p EnvironmentFiles` returns plural name but in current code singular namei is being used which is incorrect. Fixes: https://github.com/devexp-db/postgresql-setup/issues/54