### PR TITLE
Detect postgresql major version dynamically

### DIFF
--- a/.github/workflows/testing-farm.yaml
+++ b/.github/workflows/testing-farm.yaml
@@ -88,6 +88,49 @@ jobs:
           update_pull_request_status: "true"
           create_github_summary: "true"
           variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};PR_HEAD=${{ github.event.pull_request.head.sha }};"
+
+  test-checksums:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+
+    steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Test upgrade on Fedora VM
+        uses: sclorg/testing-farm-as-github-action@main
+        with:
+          api_key: ${{ secrets.TESTING_FARM_API_TOKEN }}
+          compose: Fedora-Rawhide
+          tmt_path: "tmt"
+          tmt_plan_regex: "fedora-checksums"
+          pull_request_status_name: "Fedora checksum tests"
+          update_pull_request_status: "true"
+          create_github_summary: "true"
+          variables: "REPO_URL=${{ github.server_url }}/${{ github.repository }};PR_HEAD=${{ github.event.pull_request.head.sha }};"
+
   container-test-init:
     runs-on: ubuntu-latest
 

--- a/NEWS
+++ b/NEWS
@@ -2,7 +2,7 @@
 
 New in 8.12 version:
 
-*
+* Detect PostgreSQL major version from currently installed postgres binary
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+New in 8.13 version:
+
+*
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 New in 8.12 version:
 
 * Detect PostgreSQL major version from currently installed postgres binary

--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -33,6 +33,9 @@ USER=$(id -u -n)
 # Directory containing the postgres executable
 PGENGINE=@bindir@
 
+# PostgreSQL major version from currently installed package
+PGMAJORVER=$("$PGENGINE"/postgres -V | grep -o -P '(?<=\(PostgreSQL\) )\d+(?=\D)')
+
 # Distribution README file
 README_DIST=@README_DIST@
 
@@ -59,7 +62,7 @@ option_upgradefrom="@NAME_DEFAULT_PREV_SERVICE@"
 srvsuff=
 test 0 -eq @WANT_SYSVINIT@ && srvsuff=".service"
 
-if [ @PGMAJORVERSION@ -ge 18 ]; then
+if [ "$PGMAJORVER" -ge 18 ]; then
     checksums_default_line="
                              Default behavior when initializing (not upgrading).
   --no-data-checksums        Do not enable data checksums for the data directory.
@@ -172,7 +175,7 @@ perform_initdb()
     test -w "$initdb_log" || echo "$initdb_log is not writeable by $USER"
 
     # add option to enable data checksums if flag provided
-    if [ "${option_data_checksums:-0}" -eq 1 ] && [ @PGMAJORVERSION@ -lt 18 ]; then
+    if [ "${option_data_checksums:-0}" -eq 1 ] && [ "$PGMAJORVER" -lt 18 ]; then
         add_initdb_options "--data-checksums"
     fi
 
@@ -400,8 +403,8 @@ upgrade()
         if echo "$checksums_result" | grep -q "not enabled"; then
             if [ "${option_data_checksums:-0}" -ne 1 ] \
             && ! echo "$PGSETUP_INITDB_OPTIONS" | grep -qE -- "--(no-)?data-checksums" \
-            && [ @PGMAJORVERSION@ -ge 18 ]; then
-                error "PostgreSQL @PGMAJORVERSION@ has data checksums enabled by default,"
+            && [ "$PGMAJORVER" -ge 18 ]; then
+                error "PostgreSQL $PGMAJORVER has data checksums enabled by default,"
                 error_q "while your current data directory does not. Please either use the"
                 error_q "--data-checksums flag to enable them before upgrading, or the"
                 error_q "--no-data-checksums to keep them disabled."
@@ -1070,7 +1073,7 @@ if @MOUNTPOINT@ -q "$pgdata" || @MOUNTPOINT@ -q "$(dirname "$pgdata")"; then
     warn_q $"filesystem layout should ideally look like:"
     warn_q $"/ROOT_OWNED_MOUNTPOINT/POSTGRES_OWNED_DIRECTORY/DATADIR."
     warn_q $"See the upstream documentation for more info:"
-    warn_q $"http://www.postgresql.org/docs/@PGMAJORVERSION@/static/creating-cluster.html"
+    warn_q $"http://www.postgresql.org/docs/$PGMAJORVER/static/creating-cluster.html"
 fi
 
 # See how we were called.

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Use the MAJ.MIN[~SUFF].  Note that X.X > X.X~SUFF!
-AC_INIT([postgresql-setup], [8.12], [praiskup@redhat.com])
+AC_INIT([postgresql-setup], [8.13~dev], [praiskup@redhat.com])
 AC_CONFIG_AUX_DIR(auxdir)
 config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Use the MAJ.MIN[~SUFF].  Note that X.X > X.X~SUFF!
-AC_INIT([postgresql-setup], [8.12~dev], [praiskup@redhat.com])
+AC_INIT([postgresql-setup], [8.12], [praiskup@redhat.com])
 AC_CONFIG_AUX_DIR(auxdir)
 config_aux_dir=auxdir
 AC_SUBST([config_aux_dir])

--- a/tmt/tests/virtual/checksums/enable/test.sh
+++ b/tmt/tests/virtual/checksums/enable/test.sh
@@ -36,15 +36,6 @@ rlJournalStart
     rlRun "dnf -y remove postgresql17*" 0 "Removing postgresql 17"
     rlRun "dnf -y install postgresql18-upgrade" 0 "Installing postgresql 18"
 
-    ./bin/postgresql-setup --help > pre
-
-    rlRun "autoreconf -vfi" 0 "Building and installing postgresql-setup"
-    rlRun "./configure --prefix=/usr"
-    rlRun "make"
-
-    ./bin/postgresql-setup --help > post
-    rlRun "diff pre post" 1 "Verifying help strings differ"
-
     rlRun "./bin/postgresql-setup --upgrade" 1 "Upgrading without checksums flags"
     rlRun "./bin/postgresql-setup --upgrade --data-checksums" 0 "Upgrading with checksums flag"
 

--- a/tmt/tests/virtual/checksums/pre-pg18/test.sh
+++ b/tmt/tests/virtual/checksums/pre-pg18/test.sh
@@ -10,11 +10,13 @@ rlJournalStart
     rlRun "git fetch origin \"$PR_HEAD\""
     rlRun "git checkout FETCH_HEAD"
     rlRun "cat /etc/fedora-release"
-    rlRun "dnf -y install postgresql16-server"
+    rlRun "dnf -y install postgresql18-upgrade" 0 "Installing postgresql 18"
 
     rlRun "autoreconf -vfi" 0 "Building and installing postgresql-setup"
     rlRun "./configure --prefix=/usr"
     rlRun "make"
+    rlRun "dnf -y remove postgresql-server"
+    rlRun "dnf -y install postgresql16-server"
     rlRun "./bin/postgresql-setup --init" 0 "Initializing database dir"
     rlRun "systemctl start postgresql" 0 "Starting service"
     rlRun "systemctl is-active postgresql" 0 "Verifying service running"
@@ -36,11 +38,7 @@ rlJournalStart
     rlRun "dnf -y remove postgresql16*" 0 "Removing postgresql 16"
     rlRun "dnf -y install postgresql17-upgrade" 0 "Installing postgresql 17"
 
-    rlRun "autoreconf -vfi" 0 "Building and installing postgresql-setup"
-    rlRun "./configure --prefix=/usr"
-    rlRun "make"
-
-    rlRun "./bin/postgresql-setup --upgrade --data-checksums" 0 "Upgrading with checksums flag"
+    rlRun "./bin/postgresql-setup --upgrade" 0 "Upgrading without checksums flag"
 
     rlRun "systemctl start postgresql" 0 "Starting service again"
     rlRun "systemctl is-active postgresql" 0 "Verifying service running"
@@ -54,7 +52,7 @@ rlJournalStart
 
     rlAssertNotDiffer expected.txt actual17.txt
     rlRun "systemctl stop postgresql" 0 "Stop service"
-    rlRun "pg_checksums /var/lib/pgsql/data" 0 "Verify checksums enabled"
+    rlRun "pg_checksums /var/lib/pgsql/data" 1 "Verify checksums not enabled"
   rlPhaseEnd
 
   rlPhaseStartCleanup


### PR DESCRIPTION
This enables different behaviours for versions
which do not require checksums and ones that do.

Also update release.