### PR TITLE
handle_service_envfiles: fix sed pattern and quoting for multiple entries

### DIFF
--- a/bin/postgresql-setup.in
+++ b/bin/postgresql-setup.in
@@ -670,13 +670,14 @@ handle_service_envfiles()
     local mode="$1"
     local service="$2"
 
-    local envfiles="$(systemctl show -p EnvironmentFiles "${service}.service")"\
+    local envfiles
+    envfiles="$(systemctl show -p EnvironmentFiles "${service}.service")" \
         || return
 
     test -z "$envfiles" && return
 
-    envfiles=$(echo $envfiles | \
-        sed -e 's/^EnvironmentFile=//' \
+    envfiles=$(echo "$envfiles" | \
+        sed -e 's/^EnvironmentFiles=//' \
             -e 's| ([^)]*)$||'
     )
 


### PR DESCRIPTION
systemctl show -p EnvironmentFiles outputs lines prefixed with
'EnvironmentFiles=' (plural). The sed command was using the singular
'EnvironmentFile=' which never matched, leaving paths un-stripped.

Additionally, $envfiles was unquoted in the echo, causing the shell to
collapse newlines between multiple entries into spaces. This broke the
'while read line' loop which relies on newline separation to iterate
over each file path individually.

Fix by quoting "$envfiles" to preserve newlines, and updating the sed
pattern to match the plural 'EnvironmentFiles=' prefix.

Fixes: https://github.com/devexp-db/postgresql-setup/issues/54